### PR TITLE
feat: 단일 변수 dto

### DIFF
--- a/src/main/java/com/bteam/Booking_Beacon/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/bteam/Booking_Beacon/domain/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.models.media.MediaType;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -53,8 +54,8 @@ public class AuthController {
 
     @Operation(summary = "이메일 인증 코드 메일 발송 (body에 String email)")
     @PostMapping("verify/email")
-    public ResponseEntity<VerifyEmailRes> sendVerifyEmail(@Validated @RequestBody String userEmail) {
-        return this.authService.sendVerifyEmail(userEmail);
+    public ResponseEntity<VerifyEmailRes> sendVerifyEmail(@Valid @RequestBody VerifyEmailReq verifyEmailReq) {
+        return this.authService.sendVerifyEmail(verifyEmailReq.getUserEmail());
     }
 
     @Operation(summary = "이메일 인증 코드 검증")
@@ -64,11 +65,11 @@ public class AuthController {
     }
 
     @PostMapping("login")
-//    @Operation(summary = "로그인", responses = {
-//            @ApiResponse(responseCode = "200", content = {
-//                    @Content(mediaType = "application/json", schema = @Schema(implementation = TokenRes.class))
-//            })
-//    })
+    @Operation(summary = "로그인", responses = {
+            @ApiResponse(responseCode = "200", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = TokenRes.class))
+            })
+    })
     public ResponseEntity<TokenRes> login(@Validated @RequestBody LoginReq loginReq, TokenRes tokenRes) {
         return this.authService.login(loginReq);
     }

--- a/src/main/java/com/bteam/Booking_Beacon/domain/auth/dto/request/CreatePartnerReq.java
+++ b/src/main/java/com/bteam/Booking_Beacon/domain/auth/dto/request/CreatePartnerReq.java
@@ -5,10 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 @Builder
 public class CreatePartnerReq {
-    private String partnerName;
-    private String ein;
-    private String phoneNumber;
+    private final String partnerName;
+    private final String ein;
+    private final String phoneNumber;
 }

--- a/src/main/java/com/bteam/Booking_Beacon/domain/auth/dto/request/CreateUserReq.java
+++ b/src/main/java/com/bteam/Booking_Beacon/domain/auth/dto/request/CreateUserReq.java
@@ -8,9 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
-@Setter
 @Getter // 실제 입력 필드 값을 매핑해주는 역할을 한다
 @AllArgsConstructor
+@Setter
 @Builder
 public class CreateUserReq {
     @NotNull

--- a/src/main/java/com/bteam/Booking_Beacon/domain/auth/dto/request/LoginReq.java
+++ b/src/main/java/com/bteam/Booking_Beacon/domain/auth/dto/request/LoginReq.java
@@ -5,9 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 @Builder
 public class LoginReq {
-    private String userEmail;
-    private String password;
+    private final String userEmail;
+    private final String password;
 }

--- a/src/main/java/com/bteam/Booking_Beacon/domain/auth/dto/request/UpdatePartnerReq.java
+++ b/src/main/java/com/bteam/Booking_Beacon/domain/auth/dto/request/UpdatePartnerReq.java
@@ -6,11 +6,10 @@ import lombok.Getter;
 
 import java.util.Optional;
 
-@AllArgsConstructor
 @Builder
 @Getter
 public class UpdatePartnerReq {
-    private Optional<String> partnerName;
-    private Optional<String> ein;
-    private Optional<String> phoneNumber;
+    private final Optional<String> partnerName;
+    private final Optional<String> ein;
+    private final Optional<String> phoneNumber;
 }

--- a/src/main/java/com/bteam/Booking_Beacon/domain/auth/dto/request/UpdateUserReq.java
+++ b/src/main/java/com/bteam/Booking_Beacon/domain/auth/dto/request/UpdateUserReq.java
@@ -4,12 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-@AllArgsConstructor
 @Builder
 @Getter
 public class UpdateUserReq {
-    private Long userId;
-    private String userName;
-    private String password;
-    private String userEmail;
+    private final Long userId;
+    private final String userName;
+    private final String password;
+    private final String userEmail;
 }

--- a/src/main/java/com/bteam/Booking_Beacon/domain/auth/dto/request/VerifyEmailReq.java
+++ b/src/main/java/com/bteam/Booking_Beacon/domain/auth/dto/request/VerifyEmailReq.java
@@ -1,13 +1,20 @@
 package com.bteam.Booking_Beacon.domain.auth.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
 
 @Getter
-@AllArgsConstructor
-@Builder
+//@NoArgsConstructor
 public class VerifyEmailReq {
-    private String userEmail;
-//    private String password;
+    @NotNull
+    private final String userEmail;
+
+    /*
+    생성자
+     */
+    @JsonCreator
+    VerifyEmailReq(String userEmail) {
+        this.userEmail = userEmail;
+    }
 }


### PR DESCRIPTION
## 직렬화 / 역직렬화
---
### 1. request -> server 
`json 문자열` 을 객체로 변환하는 `역직렬화` 작업이 필요합니다
이때 @Getter annotation 이 필요합니다. 
Jackson 라이브러리가 (@RequestBody annotation 을 보고) 역직렬화를 하려고 할때 @Getter annotation 을 통해 생성된 getter 메소드에서 get 을 제외한 단어를 필드의 이름으로 유추하여 역직렬화를 진행한다. 


### 2. server -> response
객체를 `json 문자열` 로 변환하는 `직렬화` 작업이 필요합니다. 
이때 @Getter 가 필요합니다. 
역직렬화와 같은 방법으로 getter 메소드에서 유추해서 직렬화 진행


### 3. 직렬화 와 역직렬화의 이유
#### 통신에서 주고 받기 편한 json, xml 을 다루기 위해 `json 문자열` 로 변환한다.


### 그렇다면 단일 멤버변수에서 에러가 발생한 이유
- 멤버변수가 단일인 클래스에서 역직렬화를 하려는 경우 역직렬화의 대상을 단정짓기 모호하다고 합니다. 그래서 에러가 발생함. 
- 이를 해결하기 위해 기본생성자(아무 파라미터가 없는 생성자)를 생성하거나. 생성자에 @JsonCreator annotation 을 통해 역직렬화 해주세요~ 라고 정의 지어야 한다고 함. 

--- 
### Reference
[https://joon2974.tistory.com/25](https://joon2974.tistory.com/25)
[https://amaran-th.github.io/Spring/[Spring]%20Spring%20DTO%EC%9D%98%20%EB%8D%B0%EC%9D%B4%ED%84%B0%20%EB%B0%94%EC%9D%B8%EB%94%A9%EA%B3%BC%20%EC%A7%81%EB%A0%AC%ED%99%94/](https://amaran-th.github.io/Spring/[Spring]%20Spring%20DTO%EC%9D%98%20%EB%8D%B0%EC%9D%B4%ED%84%B0%20%EB%B0%94%EC%9D%B8%EB%94%A9%EA%B3%BC%20%EC%A7%81%EB%A0%AC%ED%99%94/)